### PR TITLE
Add custom endpoint integration test

### DIFF
--- a/my-medusa-store/integration-tests/http/custom.spec.ts
+++ b/my-medusa-store/integration-tests/http/custom.spec.ts
@@ -1,0 +1,15 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+jest.setTimeout(60 * 1000)
+
+medusaIntegrationTestRunner({
+  inApp: true,
+  env: {},
+  testSuite: ({ api }) => {
+    describe("Custom Endpoint", () => {
+      it("GET /store/custom should return 200", async () => {
+        const response = await api.get('/store/custom')
+        expect(response.status).toEqual(200)
+      })
+    })
+  },
+})


### PR DESCRIPTION
## Summary
- test `/store/custom` endpoint using `medusaIntegrationTestRunner`

## Testing
- `yarn test:integration:http` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6879beadbe14832a96d8166e1d1f1cf0