### PR TITLE
Add Korean localization setup

### DIFF
--- a/my-medusa-store-storefront/next.config.js
+++ b/my-medusa-store-storefront/next.config.js
@@ -7,6 +7,10 @@ checkEnvVariables()
  */
 const nextConfig = {
   reactStrictMode: true,
+  i18n: {
+    locales: ["ko", "en"],
+    defaultLocale: "ko",
+  },
   logging: {
     fetches: {
       fullUrl: true,

--- a/my-medusa-store-storefront/package.json
+++ b/my-medusa-store-storefront/package.json
@@ -28,6 +28,7 @@
     "react": "19.0.0-rc-66855b96-20241106",
     "react-country-flag": "^3.1.0",
     "react-dom": "19.0.0-rc-66855b96-20241106",
+    "next-intl": "^3.8.1",
     "server-only": "^0.0.1",
     "tailwindcss-radix": "^2.8.0",
     "webpack": "^5"

--- a/my-medusa-store-storefront/src/app/[countryCode]/(checkout)/not-found.tsx
+++ b/my-medusa-store-storefront/src/app/[countryCode]/(checkout)/not-found.tsx
@@ -1,5 +1,7 @@
+"use client"
 import InteractiveLink from "@modules/common/components/interactive-link"
 import { Metadata } from "next"
+import { useTranslations } from "next-intl"
 
 export const metadata: Metadata = {
   title: "404",
@@ -7,13 +9,14 @@ export const metadata: Metadata = {
 }
 
 export default async function NotFound() {
+  const t = useTranslations('notFound')
   return (
     <div className="flex flex-col gap-4 items-center justify-center min-h-[calc(100vh-64px)]">
-      <h1 className="text-2xl-semi text-ui-fg-base">Page not found</h1>
+      <h1 className="text-2xl-semi text-ui-fg-base">{t('title')}</h1>
       <p className="text-small-regular text-ui-fg-base">
-        The page you tried to access does not exist.
+        {t('description')}
       </p>
-      <InteractiveLink href="/">Go to frontpage</InteractiveLink>
+      <InteractiveLink href="/">{t('frontpage')}</InteractiveLink>
     </div>
   )
 }

--- a/my-medusa-store-storefront/src/app/[countryCode]/(main)/cart/not-found.tsx
+++ b/my-medusa-store-storefront/src/app/[countryCode]/(main)/cart/not-found.tsx
@@ -1,6 +1,8 @@
+"use client"
 import { Metadata } from "next"
 
 import InteractiveLink from "@modules/common/components/interactive-link"
+import { useTranslations } from "next-intl"
 
 export const metadata: Metadata = {
   title: "404",
@@ -8,14 +10,14 @@ export const metadata: Metadata = {
 }
 
 export default function NotFound() {
+  const t = useTranslations('notFound')
   return (
     <div className="flex flex-col items-center justify-center min-h-[calc(100vh-64px)]">
-      <h1 className="text-2xl-semi text-ui-fg-base">Page not found</h1>
+      <h1 className="text-2xl-semi text-ui-fg-base">{t('title')}</h1>
       <p className="text-small-regular text-ui-fg-base">
-        The cart you tried to access does not exist. Clear your cookies and try
-        again.
+        {t('description')}
       </p>
-      <InteractiveLink href="/">Go to frontpage</InteractiveLink>
+      <InteractiveLink href="/">{t('frontpage')}</InteractiveLink>
     </div>
   )
 }

--- a/my-medusa-store-storefront/src/app/[countryCode]/(main)/not-found.tsx
+++ b/my-medusa-store-storefront/src/app/[countryCode]/(main)/not-found.tsx
@@ -1,6 +1,8 @@
+"use client"
 import { Metadata } from "next"
 
 import InteractiveLink from "@modules/common/components/interactive-link"
+import { useTranslations } from "next-intl"
 
 export const metadata: Metadata = {
   title: "404",
@@ -8,13 +10,14 @@ export const metadata: Metadata = {
 }
 
 export default function NotFound() {
+  const t = useTranslations('notFound')
   return (
     <div className="flex flex-col gap-4 items-center justify-center min-h-[calc(100vh-64px)]">
-      <h1 className="text-2xl-semi text-ui-fg-base">Page not found</h1>
+      <h1 className="text-2xl-semi text-ui-fg-base">{t('title')}</h1>
       <p className="text-small-regular text-ui-fg-base">
-        The page you tried to access does not exist.
+        {t('description')}
       </p>
-      <InteractiveLink href="/">Go to frontpage</InteractiveLink>
+      <InteractiveLink href="/">{t('frontpage')}</InteractiveLink>
     </div>
   )
 }

--- a/my-medusa-store-storefront/src/app/layout.tsx
+++ b/my-medusa-store-storefront/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import { getBaseURL } from "@lib/util/env"
 import { Metadata } from "next"
 import "styles/globals.css"
+import { NextIntlClientProvider } from "next-intl"
+import koMessages from "../locales/ko.json"
 
 export const metadata: Metadata = {
   metadataBase: new URL(getBaseURL()),
@@ -8,9 +10,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout(props: { children: React.ReactNode }) {
   return (
-    <html lang="en" data-mode="light">
+    <html lang="ko" data-mode="light">
       <body>
-        <main className="relative">{props.children}</main>
+        <NextIntlClientProvider locale="ko" messages={koMessages}>
+          <main className="relative">{props.children}</main>
+        </NextIntlClientProvider>
       </body>
     </html>
   )

--- a/my-medusa-store-storefront/src/app/not-found.tsx
+++ b/my-medusa-store-storefront/src/app/not-found.tsx
@@ -1,7 +1,9 @@
+"use client"
 import { ArrowUpRightMini } from "@medusajs/icons"
 import { Text } from "@medusajs/ui"
 import { Metadata } from "next"
 import Link from "next/link"
+import { useTranslations } from "next-intl"
 
 export const metadata: Metadata = {
   title: "404",
@@ -9,17 +11,18 @@ export const metadata: Metadata = {
 }
 
 export default function NotFound() {
+  const t = useTranslations('notFound')
   return (
     <div className="flex flex-col gap-4 items-center justify-center min-h-[calc(100vh-64px)]">
-      <h1 className="text-2xl-semi text-ui-fg-base">Page not found</h1>
+      <h1 className="text-2xl-semi text-ui-fg-base">{t('title')}</h1>
       <p className="text-small-regular text-ui-fg-base">
-        The page you tried to access does not exist.
+        {t('description')}
       </p>
       <Link
         className="flex gap-x-1 items-center group"
         href="/"
       >
-        <Text className="text-ui-fg-interactive">Go to frontpage</Text>
+        <Text className="text-ui-fg-interactive">{t('frontpage')}</Text>
         <ArrowUpRightMini
           className="group-hover:rotate-45 ease-in-out duration-150"
           color="var(--fg-interactive)"

--- a/my-medusa-store-storefront/src/lib/util/money.ts
+++ b/my-medusa-store-storefront/src/lib/util/money.ts
@@ -13,7 +13,7 @@ export const convertToLocale = ({
   currency_code,
   minimumFractionDigits,
   maximumFractionDigits,
-  locale = "en-US",
+  locale = "ko-KR",
 }: ConvertToLocaleParams) => {
   return currency_code && !isEmpty(currency_code)
     ? new Intl.NumberFormat(locale, {

--- a/my-medusa-store-storefront/src/locales/en.json
+++ b/my-medusa-store-storefront/src/locales/en.json
@@ -1,0 +1,9 @@
+{
+  "hero.title": "Ecommerce Starter Template",
+  "hero.subtitle": "Powered by Medusa and Next.js",
+  "hero.github": "View on GitHub",
+  "country.shippingTo": "Shipping to:",
+  "notFound.title": "Page not found",
+  "notFound.description": "The page you tried to access does not exist.",
+  "notFound.frontpage": "Go to frontpage"
+}

--- a/my-medusa-store-storefront/src/locales/ko.json
+++ b/my-medusa-store-storefront/src/locales/ko.json
@@ -1,0 +1,9 @@
+{
+  "hero.title": "전자상거래 스타터 템플릿",
+  "hero.subtitle": "Medusa와 Next.js 기반",
+  "hero.github": "GitHub에서 보기",
+  "country.shippingTo": "배송 국가:",
+  "notFound.title": "페이지를 찾을 수 없습니다",
+  "notFound.description": "요청하신 페이지가 존재하지 않습니다.",
+  "notFound.frontpage": "메인 페이지로 가기"
+}

--- a/my-medusa-store-storefront/src/modules/home/components/hero/index.tsx
+++ b/my-medusa-store-storefront/src/modules/home/components/hero/index.tsx
@@ -1,7 +1,10 @@
+"use client"
 import { Github } from "@medusajs/icons"
 import { Button, Heading } from "@medusajs/ui"
+import { useTranslations } from "next-intl"
 
 const Hero = () => {
+  const t = useTranslations('hero')
   return (
     <div className="h-[75vh] w-full border-b border-ui-border-base relative bg-ui-bg-subtle">
       <div className="absolute inset-0 z-10 flex flex-col justify-center items-center text-center small:p-32 gap-6">
@@ -10,13 +13,13 @@ const Hero = () => {
             level="h1"
             className="text-3xl leading-10 text-ui-fg-base font-normal"
           >
-            Ecommerce Starter Template
+            {t('title')}
           </Heading>
           <Heading
             level="h2"
             className="text-3xl leading-10 text-ui-fg-subtle font-normal"
           >
-            Powered by Medusa and Next.js
+            {t('subtitle')}
           </Heading>
         </span>
         <a
@@ -24,7 +27,7 @@ const Hero = () => {
           target="_blank"
         >
           <Button variant="secondary">
-            View on GitHub
+            {t('github')}
             <Github />
           </Button>
         </a>

--- a/my-medusa-store-storefront/src/modules/layout/components/country-select/index.tsx
+++ b/my-medusa-store-storefront/src/modules/layout/components/country-select/index.tsx
@@ -8,6 +8,7 @@ import {
   Transition,
 } from "@headlessui/react"
 import { Fragment, useEffect, useMemo, useState } from "react"
+import { useTranslations } from "next-intl"
 import ReactCountryFlag from "react-country-flag"
 
 import { StateType } from "@lib/hooks/use-toggle-state"
@@ -27,6 +28,7 @@ type CountrySelectProps = {
 }
 
 const CountrySelect = ({ toggleState, regions }: CountrySelectProps) => {
+  const t = useTranslations('country')
   const [current, setCurrent] = useState<
     | { country: string | undefined; region: string; label: string | undefined }
     | undefined
@@ -75,7 +77,7 @@ const CountrySelect = ({ toggleState, regions }: CountrySelectProps) => {
       >
         <ListboxButton className="py-1 w-full">
           <div className="txt-compact-small flex items-start gap-x-2">
-            <span>Shipping to:</span>
+            <span>{t('shippingTo')}</span>
             {current && (
               <span className="txt-compact-small flex items-center gap-x-2">
                 {/* @ts-ignore */}


### PR DESCRIPTION
## Summary
- add next-intl and default Korean locale
- provide Korean translations
- update hero and country select UI text
- localize 404 pages
- change currency formatting default locale to Korean

## Testing
- `yarn lint` *(fails: fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6879c0df34d0832ab37df3ea5591d3b5